### PR TITLE
feat: add courses module with CRUD

### DIFF
--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -1,3 +1,6 @@
 import { Routes } from '@angular/router';
+import { CoursesManagerComponent } from './courses/courses-manager/courses-manager';
 
-export const routes: Routes = [];
+export const routes: Routes = [
+  { path: 'cursos', component: CoursesManagerComponent },
+];

--- a/src/app/courses/course-form/course-form.html
+++ b/src/app/courses/course-form/course-form.html
@@ -1,0 +1,16 @@
+<form [formGroup]="courseForm" (ngSubmit)="onSubmit()" class="mt-3">
+  <div class="mb-3">
+    <label for="title" class="form-label">Título</label>
+    <input id="title" type="text" class="form-control" formControlName="title">
+    <div class="text-danger" *ngIf="getErrorMessage('title')">{{ getErrorMessage('title') }}</div>
+  </div>
+
+  <div class="mb-3">
+    <label for="description" class="form-label">Descripción</label>
+    <textarea id="description" class="form-control" formControlName="description"></textarea>
+    <div class="text-danger" *ngIf="getErrorMessage('description')">{{ getErrorMessage('description') }}</div>
+  </div>
+
+  <button type="submit" class="btn btn-primary me-2">Guardar</button>
+  <button type="button" class="btn btn-secondary" (click)="onReset()">Cancelar</button>
+</form>

--- a/src/app/courses/course-form/course-form.scss
+++ b/src/app/courses/course-form/course-form.scss
@@ -1,0 +1,1 @@
+/* Styles for course form */

--- a/src/app/courses/course-form/course-form.ts
+++ b/src/app/courses/course-form/course-form.ts
@@ -1,0 +1,54 @@
+import { Component, EventEmitter, Input, OnChanges, Output, SimpleChanges } from '@angular/core';
+import { FormBuilder, FormGroup, Validators, ReactiveFormsModule } from '@angular/forms';
+import { CommonModule } from '@angular/common';
+import { Course } from '../../shared/entities';
+
+@Component({
+  selector: 'app-course-form',
+  standalone: true,
+  imports: [CommonModule, ReactiveFormsModule],
+  templateUrl: './course-form.html',
+  styleUrls: ['./course-form.scss']
+})
+export class CourseFormComponent implements OnChanges {
+  @Input() course: Course | null = null;
+  @Output() save = new EventEmitter<Course>();
+
+  courseForm: FormGroup;
+
+  constructor(private fb: FormBuilder) {
+    this.courseForm = this.fb.group({
+      id: [null],
+      title: ['', [Validators.required]],
+      description: ['', [Validators.required]],
+    });
+  }
+
+  ngOnChanges(changes: SimpleChanges) {
+    if (changes['course'] && this.course) {
+      this.courseForm.patchValue(this.course);
+    }
+  }
+
+  getErrorMessage(controlName: string): string | null {
+    const ctrl = this.courseForm.get(controlName);
+    if (!ctrl || !ctrl.errors || !(ctrl.touched || ctrl.dirty)) return null;
+    const errs = ctrl.errors;
+
+    if (errs['required']) return 'Este campo es obligatorio.';
+    return null;
+  }
+
+  onSubmit() {
+    this.courseForm.markAllAsTouched();
+    if (this.courseForm.valid) {
+      this.save.emit(this.courseForm.value);
+      this.courseForm.reset();
+    }
+  }
+
+  onReset() {
+    this.courseForm.reset();
+  }
+}
+

--- a/src/app/courses/courses-manager/courses-manager.html
+++ b/src/app/courses/courses-manager/courses-manager.html
@@ -1,0 +1,4 @@
+<div class="container">
+  <app-course-form [course]="courseToEdit" (save)="saveCourse($event)"></app-course-form>
+  <app-courses-table [courses]="courses" (eliminar)="deleteCourse($event)" (editar)="editCourse($event)"></app-courses-table>
+</div>

--- a/src/app/courses/courses-manager/courses-manager.scss
+++ b/src/app/courses/courses-manager/courses-manager.scss
@@ -1,0 +1,1 @@
+/* Styles for courses manager */

--- a/src/app/courses/courses-manager/courses-manager.ts
+++ b/src/app/courses/courses-manager/courses-manager.ts
@@ -1,0 +1,44 @@
+import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { Course } from '../../shared/entities';
+import { CoursesTableComponent } from '../courses-table/courses-table';
+import { CourseFormComponent } from '../course-form/course-form';
+
+@Component({
+  selector: 'app-courses-manager',
+  standalone: true,
+  imports: [CommonModule, CoursesTableComponent, CourseFormComponent],
+  templateUrl: './courses-manager.html',
+  styleUrls: ['./courses-manager.scss']
+})
+export class CoursesManagerComponent {
+  courses: Course[] = [];
+  courseToEdit: Course | null = null;
+
+  saveCourse(course: Course) {
+    if (course.id) {
+      const index = this.courses.findIndex(c => c.id === course.id);
+      if (index !== -1) {
+        this.courses[index] = { ...course };
+        this.courses = [...this.courses];
+      }
+    } else {
+      const newCourse = { ...course, id: this.generateNewId() };
+      this.courses = [...this.courses, newCourse];
+    }
+    this.courseToEdit = null;
+  }
+
+  editCourse(course: Course) {
+    this.courseToEdit = { ...course };
+  }
+
+  deleteCourse(course: Course) {
+    this.courses = this.courses.filter(c => c.id !== course.id);
+  }
+
+  private generateNewId(): number {
+    return this.courses.length > 0 ? Math.max(...this.courses.map(c => c.id)) + 1 : 1;
+  }
+}
+

--- a/src/app/courses/courses-table/courses-table.html
+++ b/src/app/courses/courses-table/courses-table.html
@@ -1,0 +1,26 @@
+<div class="container mt-4">
+  <h2 class="mb-4 text-center">Lista de Cursos</h2>
+
+  <table mat-table [dataSource]="courses" class="table table-bordered table-striped table-hover">
+    <ng-container matColumnDef="title">
+      <th mat-header-cell *matHeaderCellDef class="text-center"> Título </th>
+      <td mat-cell *matCellDef="let element" class="text-center"> {{element.title}} </td>
+    </ng-container>
+
+    <ng-container matColumnDef="description">
+      <th mat-header-cell *matHeaderCellDef class="text-center"> Descripción </th>
+      <td mat-cell *matCellDef="let element" class="text-center"> {{element.description}} </td>
+    </ng-container>
+
+    <ng-container matColumnDef="actions">
+      <th mat-header-cell *matHeaderCellDef class="text-center"> Acciones </th>
+      <td mat-cell *matCellDef="let element" class="text-center">
+        <button class="btn btn-danger btn-sm me-2" (click)="eliminarCurso(element)">Eliminar</button>
+        <button class="btn btn-primary btn-sm" (click)="editarCurso(element)">Editar</button>
+      </td>
+    </ng-container>
+
+    <tr mat-header-row *matHeaderRowDef="displayedColumns" class="table-primary"></tr>
+    <tr mat-row *matRowDef="let row; columns: displayedColumns;"></tr>
+  </table>
+</div>

--- a/src/app/courses/courses-table/courses-table.scss
+++ b/src/app/courses/courses-table/courses-table.scss
@@ -1,0 +1,1 @@
+/* Styles for courses table */

--- a/src/app/courses/courses-table/courses-table.ts
+++ b/src/app/courses/courses-table/courses-table.ts
@@ -1,0 +1,28 @@
+import { Component, EventEmitter, Input, Output } from '@angular/core';
+import { MatTableModule } from '@angular/material/table';
+import { Course } from '../../shared/entities';
+
+@Component({
+  selector: 'app-courses-table',
+  standalone: true,
+  imports: [MatTableModule],
+  templateUrl: './courses-table.html',
+  styleUrls: ['./courses-table.scss']
+})
+export class CoursesTableComponent {
+  @Input() courses: Course[] = [];
+
+  displayedColumns: string[] = ['title', 'description', 'actions'];
+
+  @Output() eliminar = new EventEmitter<Course>();
+  @Output() editar = new EventEmitter<Course>();
+
+  eliminarCurso(curso: Course) {
+    this.eliminar.emit(curso);
+  }
+
+  editarCurso(curso: Course) {
+    this.editar.emit(curso);
+  }
+}
+

--- a/src/app/shared/entities.ts
+++ b/src/app/shared/entities.ts
@@ -6,3 +6,9 @@ export interface Student {
   dni: string;
   average: number;
 }
+
+export interface Course {
+  id: number;
+  title: string;
+  description: string;
+}


### PR DESCRIPTION
## Summary
- add Course interface
- add course form and table components
- add manager component and routing for courses

## Testing
- `npm test` *(fails: TS2554: Expected 2 arguments, but got 0)*
- `npm run build` *(fails: Inlining of fonts failed. https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;500&display=swap returned status code: 403)*

------
https://chatgpt.com/codex/tasks/task_e_6892b688e0c8832097392b93f5b59293