### PR TITLE
feat: unificar gestion de estudiantes

### DIFF
--- a/src/app/add-form/add-form.spec.ts
+++ b/src/app/add-form/add-form.spec.ts
@@ -1,17 +1,18 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { AddFormComponent } from './add-form';
+import { StudentFormComponent } from './add-form';
+import { MatSnackBarModule } from '@angular/material/snack-bar';
 
-describe('AddForm', () => {
-  let component: AddFormComponent;
-  let fixture: ComponentFixture<AddFormComponent>;
+describe('StudentFormComponent', () => {
+  let component: StudentFormComponent;
+  let fixture: ComponentFixture<StudentFormComponent>;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [AddFormComponent]
+      imports: [StudentFormComponent, MatSnackBarModule]
     })
     .compileComponents();
 
-    fixture = TestBed.createComponent(AddFormComponent);
+    fixture = TestBed.createComponent(StudentFormComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();
   });

--- a/src/app/add-form/add-form.ts
+++ b/src/app/add-form/add-form.ts
@@ -2,12 +2,12 @@ import { Component, Input, Output, EventEmitter, OnChanges, SimpleChanges } from
 import { FormGroup, FormBuilder, Validators, ReactiveFormsModule } from '@angular/forms';
 import { Student } from '../shared/entities';
 import { CommonModule } from '@angular/common';
-import { MatSnackBar } from '@angular/material/snack-bar';
+import { MatSnackBar, MatSnackBarModule } from '@angular/material/snack-bar';
 
 @Component({
   selector: 'app-student-form',
   standalone: true,
-  imports: [CommonModule, ReactiveFormsModule],
+  imports: [CommonModule, ReactiveFormsModule, MatSnackBarModule],
   templateUrl: './add-form.html',
   styleUrls: ['./add-form.scss']
 })

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -10,10 +10,6 @@ export const routes: Routes = [
     loadComponent: () => import('./features/students/students-manager/students-manager').then(m => m.StudentsManagerComponent)
   },
   {
-    path: 'add-student',
-    loadComponent: () => import('./add-form/add-form').then(m => m.StudentFormComponent)
-  },
-  {
     path: 'cursos',
     loadComponent: () => import('./features/course/courses/courses').then(m => m.CoursesComponent)
   },

--- a/src/app/features/students/students-manager/students-manager.html
+++ b/src/app/features/students/students-manager/students-manager.html
@@ -1,14 +1,15 @@
-<!-- Tabla de estudiantes -->
-<ng-container *ngIf="students$ | async as students">
-  <app-students-table
-    [students]="students"
-    (editar)="onEditar($event)"
-    (eliminar)="onEliminar($event)">
-  </app-students-table>
-</ng-container>
-<!-- Formulario de edición -->
-<app-edit-form
-  *ngIf="estudianteEditando"
-  [estudiante]="estudianteEditando"
-  (guardar)="onGuardarEditado($event)">
-</app-edit-form>
+<div class="container">
+  <app-student-form
+    [estudiante]="estudianteEditando"
+    (formSubmitted)="onGuardarEditado($event)"
+    (cancel)="onCancelar()">
+  </app-student-form>
+
+  <ng-container *ngIf="students$ | async as students">
+    <app-students-table
+      [students]="students"
+      (editar)="onEditar($event)"
+      (eliminar)="onEliminar($event)">
+    </app-students-table>
+  </ng-container>
+</div>

--- a/src/app/features/students/students-manager/students-manager.ts
+++ b/src/app/features/students/students-manager/students-manager.ts
@@ -3,14 +3,14 @@ import { CommonModule } from '@angular/common';
 import { BehaviorSubject } from 'rxjs';
 import { Student } from '../../../shared/entities';
 import { StudentsTableComponent } from '../students-table/students-table';
-import { EditForm } from '../../../edit-form/edit-form';
+import { StudentFormComponent } from '../../../add-form/add-form';
 @Component({
   selector: 'app-students-manager',
   standalone: true,
   imports: [
     CommonModule,
     StudentsTableComponent,
-    EditForm
+    StudentFormComponent
   ],
   templateUrl: './students-manager.html',
   styleUrls: ['./students-manager.scss']
@@ -51,23 +51,13 @@ export class StudentsManagerComponent {
     this.estudianteEditando = null;
   }
 
-  onNuevo() {
-  this.estudianteEditando = {
-    id: 0, // se generará nuevo ID después
-    name: '',
-    surname: '',
-    dni: '',
-    age: 0,
-    average: 0
-  }
-}
-
   private generarNuevoId(current: Student[]): number {
     return current.length > 0
       ? Math.max(...current.map(s => s.id)) + 1
       : 1;
   }
+
   get studentsList(): Student[] {
-  return this.studentsSubject.value;
-}
+    return this.studentsSubject.value;
+  }
 }

--- a/src/app/navbar/navbar.html
+++ b/src/app/navbar/navbar.html
@@ -14,11 +14,6 @@
       </a>
     </li>
     <li class="nav-item mb-2">
-      <a class="nav-link text-white" routerLink="/add-student" routerLinkActive="active">
-        <i class="bi bi-person-plus-fill me-2"></i> Agregar Estudiante
-      </a>
-    </li>
-    <li class="nav-item mb-2">
       <a class="nav-link text-white" routerLink="/cursos" routerLinkActive="active">
         <i class="bi bi-bar-chart-fill me-2"></i> Cursos
       </a>

--- a/src/app/shared/directives/bigtitle.spec.ts
+++ b/src/app/shared/directives/bigtitle.spec.ts
@@ -1,8 +1,11 @@
 import { Bigtitle } from './bigtitle';
+import { ElementRef, Renderer2 } from '@angular/core';
 
 describe('Bigtitle', () => {
   it('should create an instance', () => {
-    const directive = new Bigtitle();
+    const elRefMock = { nativeElement: document.createElement('div') } as ElementRef;
+    const rendererMock = { setStyle: () => {} } as unknown as Renderer2;
+    const directive = new Bigtitle(elRefMock, rendererMock);
     expect(directive).toBeTruthy();
   });
 });


### PR DESCRIPTION
## Summary
- Integrate student creation and listing into a single view with editable table
- Simplify navigation to a single “Estudiantes” link
- Ensure student form provides snackbar feedback

## Testing
- `npm test -- --watch=false` *(fails: No binary for Chrome browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_e_68938298019883208a10f4e4057f08f0