### PR TITLE
feat: add NgRx auth state management

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,10 @@ ng e2e
 
 Angular CLI does not come with an end-to-end testing framework by default. You can choose one that suits your needs.
 
+## State management
+
+This project uses [NgRx](https://ngrx.io/) for handling authentication state via actions, reducers, and effects.
+
 ## Additional Resources
 
 For more information on using the Angular CLI, including detailed command references, visit the [Angular CLI Overview and Command Reference](https://angular.dev/tools/cli) page.

--- a/package.json
+++ b/package.json
@@ -33,6 +33,8 @@
     "@angular/ssr": "^20.1.1",
     "bootstrap": "^5.3.7",
     "express": "^5.1.0",
+    "@ngrx/effects": "^18.0.0",
+    "@ngrx/store": "^18.0.0",
     "rxjs": "~7.8.0",
     "tslib": "^2.3.0"
   },

--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -5,13 +5,19 @@ import { routes } from './app.routes';
 //import { provideClientHydration, withEventReplay } from '@angular/platform-browser';
 
 import { provideHttpClient, withFetch } from '@angular/common/http';
+import { provideEffects } from '@ngrx/effects';
+import { provideStore } from '@ngrx/store';
+import { authReducer } from './core/auth/store/auth.reducer';
+import * as AuthEffects from './core/auth/store/auth.effects';
 
 export const appConfig: ApplicationConfig = {
   providers: [
     provideBrowserGlobalErrorListeners(),
     provideZonelessChangeDetection(),
-    provideRouter(routes), 
+    provideRouter(routes),
     //provideClientHydration(withEventReplay()),
-    provideHttpClient(withFetch())
+    provideHttpClient(withFetch()),
+    provideStore({ auth: authReducer }),
+    provideEffects(AuthEffects)
   ]
 };

--- a/src/app/core/auth/store/auth.actions.ts
+++ b/src/app/core/auth/store/auth.actions.ts
@@ -1,0 +1,18 @@
+import { createAction, props } from '@ngrx/store';
+
+export const loginStart = createAction(
+  '[Auth] Login Start',
+  props<{ email: string; password: string }>()
+);
+
+export const login = createAction(
+  '[Auth] Login',
+  props<{ email: string; name: string; admin: boolean }>()
+);
+
+export const loginFailure = createAction(
+  '[Auth] Login Failure',
+  props<{ error: string }>()
+);
+
+export const logout = createAction('[Auth] Logout');

--- a/src/app/core/auth/store/auth.effects.ts
+++ b/src/app/core/auth/store/auth.effects.ts
@@ -1,0 +1,61 @@
+import { inject } from '@angular/core';
+import { Actions, createEffect, ofType } from '@ngrx/effects';
+import { of } from 'rxjs';
+import { catchError, exhaustMap, map, tap } from 'rxjs/operators';
+import { Router } from '@angular/router';
+
+import * as AuthActions from './auth.actions';
+import { AuthService } from '../auth.service';
+import { RoutePath } from '../../../shared/route-path';
+
+export const login$ = createEffect(
+  (
+    actions$ = inject(Actions) as Actions,
+    auth = inject(AuthService)
+  ) =>
+    actions$.pipe(
+      ofType(AuthActions.loginStart),
+      exhaustMap(({ email, password }) =>
+        auth.login(email, password).pipe(
+          map(user =>
+            AuthActions.login({
+              email: user.email,
+              name: user.name,
+              admin: user.role === 'admin',
+            })
+          ),
+          catchError(err =>
+            of(AuthActions.loginFailure({ error: err?.message || 'Login failed' }))
+          )
+        )
+      )
+    )
+);
+
+export const loginSuccess$ = createEffect(
+  (
+    actions$ = inject(Actions) as Actions,
+    router = inject(Router)
+  ) =>
+    actions$.pipe(
+      ofType(AuthActions.login),
+      tap(() => router.navigate(['/', RoutePath.Dashboard]))
+    ),
+  { dispatch: false }
+);
+
+export const logout$ = createEffect(
+  (
+    actions$ = inject(Actions) as Actions,
+    auth = inject(AuthService),
+    router = inject(Router)
+  ) =>
+    actions$.pipe(
+      ofType(AuthActions.logout),
+      tap(() => {
+        auth.logout();
+        router.navigate(['/', RoutePath.Login]);
+      })
+    ),
+  { dispatch: false }
+);

--- a/src/app/core/auth/store/auth.reducer.ts
+++ b/src/app/core/auth/store/auth.reducer.ts
@@ -1,0 +1,48 @@
+import { createReducer, on } from '@ngrx/store';
+import * as AuthActions from './auth.actions';
+
+export interface AuthState {
+  email: string | null;
+  name: string | null;
+  isAdmin: boolean | null;
+  isLoggedIn: boolean;
+  error: string | null;
+}
+
+export const initialAuthState: AuthState = {
+  email: null,
+  name: null,
+  isAdmin: null,
+  isLoggedIn: false,
+  error: null,
+};
+
+export const authReducer = createReducer(
+  initialAuthState,
+  on(
+    AuthActions.login,
+    (state: AuthState, { email, name, admin }: { email: string; name: string; admin: boolean }) => ({
+      ...state,
+      email,
+      name,
+      isAdmin: admin,
+      isLoggedIn: true,
+      error: null,
+    })
+  ),
+  on(AuthActions.logout, (state: AuthState) => ({
+    ...state,
+    email: null,
+    name: null,
+    isAdmin: null,
+    isLoggedIn: false,
+    error: null,
+  })),
+  on(
+    AuthActions.loginFailure,
+    (state: AuthState, { error }: { error: string }) => ({
+      ...state,
+      error,
+    })
+  )
+);

--- a/src/app/features/auth/login/login.ts
+++ b/src/app/features/auth/login/login.ts
@@ -1,9 +1,8 @@
 import { Component } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { ReactiveFormsModule, FormBuilder, Validators, FormGroup } from '@angular/forms';
-import { Router, ActivatedRoute } from '@angular/router';
-import { AuthService } from '../../../core/auth/auth.service';
-import { RoutePath } from '../../../shared/route-path';
+import { Store } from '@ngrx/store';
+import * as AuthActions from '../../../core/auth/store/auth.actions';
 
 @Component({
   selector: 'app-login',
@@ -13,17 +12,13 @@ import { RoutePath } from '../../../shared/route-path';
   styleUrls: ['./login.scss']
 })
 export class LoginComponent {
-  RoutePath = RoutePath;
-
   form!: FormGroup;                // 👈 declarar acá
   loading = false;
   errorMsg: string | null = null;
 
   constructor(
     private fb: FormBuilder,       // 👈 inyectado
-    private auth: AuthService,
-    private router: Router,
-    private route: ActivatedRoute
+    private store: Store
   ) {
     // 👇 inicializar aquí (ya existe this.fb)
     this.form = this.fb.group({
@@ -40,15 +35,6 @@ export class LoginComponent {
     this.loading = true;
 
     const { email, password } = this.form.value;
-    this.auth.login(email, password).subscribe({
-      next: () => {
-        const returnUrl = this.route.snapshot.queryParamMap.get('returnUrl') || `/${RoutePath.Dashboard}`;
-        this.router.navigateByUrl(returnUrl);
-      },
-      error: (e) => {
-        this.errorMsg = e?.message || 'No se pudo iniciar sesión';
-        this.loading = false;
-      }
-    });
+    this.store.dispatch(AuthActions.loginStart({ email, password }));
   }
 }

--- a/src/app/toolbar/toolbar.ts
+++ b/src/app/toolbar/toolbar.ts
@@ -5,6 +5,8 @@ import { Router, NavigationEnd } from '@angular/router';
 import { filter, map, startWith, distinctUntilChanged, combineLatest, Observable } from 'rxjs';
 import { LayoutService } from '../core/layout/layout.services';
 import { AuthService } from '../core/auth/auth.service';
+import { Store } from '@ngrx/store';
+import * as AuthActions from '../core/auth/store/auth.actions';
 import { User } from '../shared/entities';
 
 type Vm = {
@@ -25,6 +27,7 @@ export class Toolbar implements OnInit {
   private router = inject(Router);
   private layout = inject(LayoutService);
   private auth = inject(AuthService);
+  private store: Store = inject(Store);
 
   vm$!: Observable<Vm>;
 
@@ -51,5 +54,5 @@ export class Toolbar implements OnInit {
 
   toggleSidebar(): void { this.layout.toggleSidebar(); }
   login(): void { this.router.navigate(['/login']); }
-  logout(): void { this.auth.logout(); this.router.navigate(['/login']); }
+  logout(): void { this.store.dispatch(AuthActions.logout()); }
 }


### PR DESCRIPTION
## Summary
- add NgRx store and effects for authentication
- dispatch login and logout actions from components
- configure store and effects providers

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@ngrx%2feffects)*
- `npm test` *(fails: Cannot find module '@ngrx/effects' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_68c0536f216c8320b2a81115a0e3f19f